### PR TITLE
[Cisco CustomLink] - Added new condition to redirect to externalLink …

### DIFF
--- a/packages/core/src/manifest/stage/JobStageExecutionLogs.tsx
+++ b/packages/core/src/manifest/stage/JobStageExecutionLogs.tsx
@@ -51,6 +51,16 @@ export class JobStageExecutionLogs extends React.Component<IJobStageExecutionLog
   public render() {
     const { manifest } = this.state;
     const { externalLink, podNamesProviders, location, account } = this.props;
+
+    // Added for Cisco : Without checking manifest.empty(), redirect to link if it didnt contain {{
+    if (externalLink && !externalLink.includes('{{')) {
+      return (
+        <a target="_blank" href={externalLink}>
+          Console Output (External)
+        </a>
+      );
+    }
+
     // prefer links to external logging platforms
     if (!isEmpty(manifest) && externalLink) {
       return (


### PR DESCRIPTION
## Summary
**Project Jira :** [Ref](https://devopsmx.atlassian.net/browse/OP-21250)
**Project Doc :** NA

**Feature :** CustomLink Feature 
**Solution :** Added new condition to redirect to externalLink without checking manifest.empty()

### How changes are verified
Deployed img on ns=testframe and verified from UI : http://testframeappledeck.cve.apple.opsmx.net/#/applications/amanapp/executions?pipeline=run2
Links are picking old podnames inspite of deleting the jobs.

## Documentation Updates
Do we need to update dashboards? No
Do we need to update SOP, new hire wiki or other documents? No

## Rollback, Deployment Details
Can this change be rolled back automatically without any issue?  Yes
Is this a backwards-compatible change in your opinion ?  Yes
**Pre deployment steps :** QA need to verify in cisco env
**Post deployment steps :** QA need to verify in cisco env